### PR TITLE
Add favourites feature

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -1,47 +1,131 @@
-import React from "react";
-import { Routes, Route } from "react-router-dom";
-import { Flex, Text } from "@chakra-ui/core";
+import React, { useState, useEffect } from 'react';
+import { Routes, Route } from 'react-router-dom';
+import { Flex, Text } from '@chakra-ui/core';
 
-import Launches from "./launches";
-import Launch from "./launch";
-import Home from "./home";
-import LaunchPads from "./launch-pads";
-import LaunchPad from "./launch-pad";
+import Launches from './launches';
+import Launch from './launch';
+import Home from './home';
+import LaunchPads from './launch-pads';
+import LaunchPad from './launch-pad';
 
 export default function App() {
-  return (
-    <div>
-      <NavBar />
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/launches" element={<Launches />} />
-        <Route path="/launches/:launchId" element={<Launch />} />
-        <Route path="/launch-pads" element={<LaunchPads />} />
-        <Route path="/launch-pads/:launchPadId" element={<LaunchPad />} />
-      </Routes>
-    </div>
-  );
+	const [favouriteLaunches, setFavouriteLaunches] = useState([]);
+	const [favouriteLaunchPads, setFavouriteLaunchPads] = useState([]);
+
+	const markAsFavouriteLaunch = (launch, e) => {
+		e.preventDefault();
+
+		let newFavouriteLaunches = favouriteLaunches;
+
+		const index = (newFavouriteLaunches || []).findIndex(
+			item => item.flight_number === launch.flight_number
+		);
+		if (index > -1) {
+			newFavouriteLaunches.splice(index, 1);
+		} else {
+			newFavouriteLaunches.push(launch);
+		}
+
+		setFavouriteLaunches([...newFavouriteLaunches]);
+	};
+
+	const markAsFavouriteLaunchPad = (launchPad, e) => {
+		e.preventDefault();
+
+		let newFavouriteLaunchPads = favouriteLaunchPads;
+
+		const index = (newFavouriteLaunchPads || []).findIndex(item => item.id === launchPad.id);
+		if (index > -1) {
+			newFavouriteLaunchPads.splice(index, 1);
+		} else {
+			newFavouriteLaunchPads.push(launchPad);
+		}
+
+		setFavouriteLaunchPads([...newFavouriteLaunchPads]);
+	};
+
+	useEffect(() => {
+		const favouriteLaunches = JSON.parse(localStorage.getItem('favouriteLaunches')) || [];
+		if (favouriteLaunches.length > 0) {
+			setFavouriteLaunches(favouriteLaunches);
+		}
+	}, []);
+
+	useEffect(() => {
+		const favouriteLaunchPads = JSON.parse(localStorage.getItem('favouriteLaunchPads')) || [];
+		if (favouriteLaunchPads.length > 0) {
+			setFavouriteLaunchPads(favouriteLaunchPads);
+		}
+	}, []);
+
+	useEffect(() => {
+		localStorage.setItem('favouriteLaunches', JSON.stringify(favouriteLaunches));
+	}, [favouriteLaunches]);
+
+	useEffect(() => {
+		localStorage.setItem('favouriteLaunchPads', JSON.stringify(favouriteLaunchPads));
+	}, [favouriteLaunchPads]);
+
+	return (
+		<div>
+			<NavBar />
+			<Routes>
+				<Route path="/" element={<Home />} />
+				<Route
+					path="/launches"
+					element={
+						<Launches
+							favouriteLaunches={favouriteLaunches}
+							markAsFavouriteLaunch={markAsFavouriteLaunch}
+						/>
+					}
+				/>
+				<Route
+					path="/launches/:launchId"
+					element={
+						<Launch
+							favouriteLaunches={favouriteLaunches}
+							markAsFavouriteLaunch={markAsFavouriteLaunch}
+						/>
+					}
+				/>
+				<Route
+					path="/launch-pads"
+					element={
+						<LaunchPads
+							favouriteLaunchPads={favouriteLaunchPads}
+							markAsFavouriteLaunchPad={markAsFavouriteLaunchPad}
+						/>
+					}
+				/>
+				<Route
+					path="/launch-pads/:launchPadId"
+					element={
+						<LaunchPad
+							favouriteLaunchPads={favouriteLaunchPads}
+							markAsFavouriteLaunchPad={markAsFavouriteLaunchPad}
+						/>
+					}
+				/>
+			</Routes>
+		</div>
+	);
 }
 
 function NavBar() {
-  return (
-    <Flex
-      as="nav"
-      align="center"
-      justify="space-between"
-      wrap="wrap"
-      padding="6"
-      bg="gray.800"
-      color="white"
-    >
-      <Text
-        fontFamily="mono"
-        letterSpacing="2px"
-        fontWeight="bold"
-        fontSize="lg"
-      >
-        ¡SPACE·R0CKETS!
-      </Text>
-    </Flex>
-  );
+	return (
+		<Flex
+			as="nav"
+			align="center"
+			justify="space-between"
+			wrap="wrap"
+			padding="6"
+			bg="gray.800"
+			color="white"
+		>
+			<Text fontFamily="mono" letterSpacing="2px" fontWeight="bold" fontSize="lg">
+				¡SPACE·R0CKETS!
+			</Text>
+		</Flex>
+	);
 }

--- a/src/components/favouritesDrawer.js
+++ b/src/components/favouritesDrawer.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import {
+	Button,
+	Drawer,
+	DrawerBody,
+	DrawerHeader,
+	DrawerOverlay,
+	DrawerContent,
+	DrawerCloseButton,
+	Stat,
+	StatLabel,
+	StatHelpText,
+	useDisclosure
+} from '@chakra-ui/core';
+import { LaunchPadItem } from './launch-pads';
+import { LaunchItem } from './launches';
+
+export default function FavouritesDrawer({ favouriteItems, markAsFavourite }) {
+	const { isOpen, onOpen, onClose } = useDisclosure();
+	const btnRef = React.useRef();
+
+	return (
+		<>
+			<Button ref={btnRef} leftIcon="star" variantColor="yellow" onClick={onOpen}>
+				See favourites
+			</Button>
+			<Drawer
+				isOpen={isOpen}
+				placement="right"
+				onClose={onClose}
+				finalFocusRef={btnRef}
+				scrollBehavior={'inside'}
+			>
+				<DrawerOverlay />
+				<DrawerContent>
+					<DrawerCloseButton />
+					<DrawerHeader>Favourites</DrawerHeader>
+					{Array.isArray(favouriteItems) && favouriteItems.length > 0 ? (
+						<DrawerBody>
+							<Stat>
+								<StatLabel>{favouriteItems[0].id ? 'Launch Pads' : 'Launches'}</StatLabel>
+								<StatHelpText>({favouriteItems.length})</StatHelpText>
+							</Stat>
+							{favouriteItems.map(item =>
+								item.id ? (
+									<LaunchPadItem
+										key={item.id}
+										launchPad={item}
+										favouriteLaunchPads={favouriteItems}
+										markAsFavouriteLaunchPad={markAsFavourite}
+									/>
+								) : (
+									<LaunchItem
+										key={item.flight_number}
+										launch={item}
+										favouriteLaunches={favouriteItems}
+										markAsFavouriteLaunch={markAsFavourite}
+									/>
+								)
+							)}
+						</DrawerBody>
+					) : (
+						<DrawerBody>No favourites added</DrawerBody>
+					)}
+				</DrawerContent>
+			</Drawer>
+		</>
+	);
+}

--- a/src/components/launch-pad.js
+++ b/src/components/launch-pad.js
@@ -1,169 +1,185 @@
-import React from "react";
-import { useParams } from "react-router-dom";
-import { MapPin, Navigation } from "react-feather";
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import { MapPin, Navigation } from 'react-feather';
 import {
-  Flex,
-  Heading,
-  Badge,
-  Stat,
-  StatLabel,
-  StatNumber,
-  StatHelpText,
-  SimpleGrid,
-  Box,
-  Text,
-  Spinner,
-  Stack,
-  AspectRatioBox,
-} from "@chakra-ui/core";
+	Flex,
+	Heading,
+	Badge,
+	Stat,
+	StatLabel,
+	StatNumber,
+	StatHelpText,
+	SimpleGrid,
+	Box,
+	Text,
+	Spinner,
+	Stack,
+	AspectRatioBox,
+	IconButton
+} from '@chakra-ui/core';
 
-import { useSpaceX } from "../utils/use-space-x";
-import Error from "./error";
-import Breadcrumbs from "./breadcrumbs";
-import { LaunchItem } from "./launches";
+import { useSpaceX } from '../utils/use-space-x';
+import Error from './error';
+import Breadcrumbs from './breadcrumbs';
+import { LaunchItem } from './launches';
 
-export default function LaunchPad() {
-  let { launchPadId } = useParams();
-  const { data: launchPad, error } = useSpaceX(`/launchpads/${launchPadId}`);
+export default function LaunchPad({ favouriteLaunchPads, markAsFavouriteLaunchPad }) {
+	let { launchPadId } = useParams();
+	const { data: launchPad, error } = useSpaceX(`/launchpads/${launchPadId}`);
 
-  const { data: launches } = useSpaceX(launchPad ? "/launches/past" : null, {
-    limit: 3,
-    order: "desc",
-    sort: "launch_date_utc",
-    site_id: launchPad?.site_id,
-  });
+	const { data: launches } = useSpaceX(launchPad ? '/launches/past' : null, {
+		limit: 3,
+		order: 'desc',
+		sort: 'launch_date_utc',
+		site_id: launchPad?.site_id
+	});
 
-  if (error) return <Error />;
-  if (!launchPad) {
-    return (
-      <Flex justifyContent="center" alignItems="center" minHeight="50vh">
-        <Spinner size="lg" />
-      </Flex>
-    );
-  }
+	if (error) return <Error />;
+	if (!launchPad) {
+		return (
+			<Flex justifyContent="center" alignItems="center" minHeight="50vh">
+				<Spinner size="lg" />
+			</Flex>
+		);
+	}
 
-  return (
-    <div>
-      <Breadcrumbs
-        items={[
-          { label: "Home", to: "/" },
-          { label: "Launch Pads", to: ".." },
-          { label: launchPad.name },
-        ]}
-      />
-      <Header launchPad={launchPad} />
-      <Box m={[3, 6]}>
-        <LocationAndVehicles launchPad={launchPad} />
-        <Text color="gray.700" fontSize={["md", null, "lg"]} my="8">
-          {launchPad.details}
-        </Text>
-        <Map location={launchPad.location} />
-        <RecentLaunches launches={launches} />
-      </Box>
-    </div>
-  );
+	const isFavourite = (favouriteLaunchPads || []).findIndex(item => item.id === launchPad.id) > -1;
+
+	return (
+		<div>
+			<Breadcrumbs
+				items={[
+					{ label: 'Home', to: '/' },
+					{ label: 'Launch Pads', to: '..' },
+					{ label: launchPad.name }
+				]}
+			/>
+			<Header
+				launchPad={launchPad}
+				isFavourite={isFavourite}
+				markAsFavouriteLaunchPad={markAsFavouriteLaunchPad}
+			/>
+			<Box m={[3, 6]}>
+				<LocationAndVehicles launchPad={launchPad} />
+				<Text color="gray.700" fontSize={['md', null, 'lg']} my="8">
+					{launchPad.details}
+				</Text>
+				<Map location={launchPad.location} />
+				<RecentLaunches launches={launches} />
+			</Box>
+		</div>
+	);
 }
 
-const randomColor = (start = 200, end = 250) =>
-  `hsl(${start + end * Math.random()}, 80%, 90%)`;
+const randomColor = (start = 200, end = 250) => `hsl(${start + end * Math.random()}, 80%, 90%)`;
 
-function Header({ launchPad }) {
-  return (
-    <Flex
-      background={`linear-gradient(${randomColor()}, ${randomColor()})`}
-      bgPos="center"
-      bgSize="cover"
-      bgRepeat="no-repeat"
-      minHeight="15vh"
-      position="relative"
-      flexDirection={["column", "row"]}
-      p={[2, 6]}
-      alignItems="flex-end"
-      justifyContent="space-between"
-    >
-      <Heading
-        color="gray.900"
-        display="inline"
-        mx={[2, 4]}
-        my="2"
-        fontSize={["md", "3xl"]}
-        borderRadius="lg"
-      >
-        {launchPad.site_name_long}
-      </Heading>
-      <Stack isInline spacing="3">
-        <Badge variantColor="purple" fontSize={["sm", "md"]}>
-          {launchPad.successful_launches}/{launchPad.attempted_launches}{" "}
-          successful
-        </Badge>
-        {launchPad.stats === "active" ? (
-          <Badge variantColor="green" fontSize={["sm", "md"]}>
-            Active
-          </Badge>
-        ) : (
-          <Badge variantColor="red" fontSize={["sm", "md"]}>
-            Retired
-          </Badge>
-        )}
-      </Stack>
-    </Flex>
-  );
+function Header({ launchPad, isFavourite, markAsFavouriteLaunchPad }) {
+	return (
+		<Flex
+			background={`linear-gradient(${randomColor()}, ${randomColor()})`}
+			bgPos="center"
+			bgSize="cover"
+			bgRepeat="no-repeat"
+			minHeight="15vh"
+			position="relative"
+			flexDirection={['column', 'row']}
+			p={[2, 6]}
+			alignItems="flex-end"
+			justifyContent="space-between"
+		>
+			<Box>
+				<Heading
+					color="gray.900"
+					display="inline"
+					mx={[2, 4]}
+					my="2"
+					fontSize={['md', '3xl']}
+					borderRadius="lg"
+				>
+					{launchPad.site_name_long}
+				</Heading>
+				<IconButton
+					aria-label="Mark as favourite"
+					icon="star"
+					size="lg"
+					variant="ghost"
+					fontSize={['lg', '4xl']}
+					mb="5"
+					ml="5"
+					variantColor={isFavourite ? 'yellow' : 'gray'}
+					onClick={e => markAsFavouriteLaunchPad(launchPad, e)}
+				/>
+			</Box>
+			<Stack isInline spacing="3">
+				<Badge variantColor="purple" fontSize={['sm', 'md']}>
+					{launchPad.successful_launches}/{launchPad.attempted_launches} successful
+				</Badge>
+				{launchPad.stats === 'active' ? (
+					<Badge variantColor="green" fontSize={['sm', 'md']}>
+						Active
+					</Badge>
+				) : (
+					<Badge variantColor="red" fontSize={['sm', 'md']}>
+						Retired
+					</Badge>
+				)}
+			</Stack>
+		</Flex>
+	);
 }
 
 function LocationAndVehicles({ launchPad }) {
-  return (
-    <SimpleGrid columns={[1, 1, 2]} borderWidth="1px" p="4" borderRadius="md">
-      <Stat>
-        <StatLabel display="flex">
-          <Box as={MapPin} width="1em" />{" "}
-          <Box ml="2" as="span">
-            Location
-          </Box>
-        </StatLabel>
-        <StatNumber fontSize="xl">{launchPad.location.name}</StatNumber>
-        <StatHelpText>{launchPad.location.region}</StatHelpText>
-      </Stat>
-      <Stat>
-        <StatLabel display="flex">
-          <Box as={Navigation} width="1em" />{" "}
-          <Box ml="2" as="span">
-            Vehicles
-          </Box>
-        </StatLabel>
-        <StatNumber fontSize="xl">
-          {launchPad.vehicles_launched.join(", ")}
-        </StatNumber>
-      </Stat>
-    </SimpleGrid>
-  );
+	return (
+		<SimpleGrid columns={[1, 1, 2]} borderWidth="1px" p="4" borderRadius="md">
+			<Stat>
+				<StatLabel display="flex">
+					<Box as={MapPin} width="1em" />{' '}
+					<Box ml="2" as="span">
+						Location
+					</Box>
+				</StatLabel>
+				<StatNumber fontSize="xl">{launchPad.location.name}</StatNumber>
+				<StatHelpText>{launchPad.location.region}</StatHelpText>
+			</Stat>
+			<Stat>
+				<StatLabel display="flex">
+					<Box as={Navigation} width="1em" />{' '}
+					<Box ml="2" as="span">
+						Vehicles
+					</Box>
+				</StatLabel>
+				<StatNumber fontSize="xl">{launchPad.vehicles_launched.join(', ')}</StatNumber>
+			</Stat>
+		</SimpleGrid>
+	);
 }
 
 function Map({ location }) {
-  return (
-    <AspectRatioBox ratio={16 / 5}>
-      <Box
-        as="iframe"
-        src={`https://maps.google.com/maps?q=${location.latitude}, ${location.longitude}&z=15&output=embed`}
-        alt="demo"
-      />
-    </AspectRatioBox>
-  );
+	return (
+		<AspectRatioBox ratio={16 / 5}>
+			<Box
+				as="iframe"
+				src={`https://maps.google.com/maps?q=${location.latitude}, ${location.longitude}&z=15&output=embed`}
+				alt="demo"
+			/>
+		</AspectRatioBox>
+	);
 }
 
 function RecentLaunches({ launches }) {
-  if (!launches?.length) {
-    return null;
-  }
-  return (
-    <Stack my="8" spacing="3">
-      <Text fontSize="xl" fontWeight="bold">
-        Last launches
-      </Text>
-      <SimpleGrid minChildWidth="350px" spacing="4">
-        {launches.map((launch) => (
-          <LaunchItem launch={launch} key={launch.flight_number} />
-        ))}
-      </SimpleGrid>
-    </Stack>
-  );
+	if (!launches?.length) {
+		return null;
+	}
+	return (
+		<Stack my="8" spacing="3">
+			<Text fontSize="xl" fontWeight="bold">
+				Last launches
+			</Text>
+			<SimpleGrid minChildWidth="350px" spacing="4">
+				{launches.map(launch => (
+					<LaunchItem launch={launch} key={launch.flight_number} />
+				))}
+			</SimpleGrid>
+		</Stack>
+	);
 }

--- a/src/components/launch-pads.js
+++ b/src/components/launch-pads.js
@@ -1,94 +1,110 @@
-import React from "react";
-import { Badge, Box, SimpleGrid, Text } from "@chakra-ui/core";
-import { Link } from "react-router-dom";
+import React from 'react';
+import { Badge, Box, SimpleGrid, Text, IconButton } from '@chakra-ui/core';
+import { Link } from 'react-router-dom';
 
-import Error from "./error";
-import Breadcrumbs from "./breadcrumbs";
-import LoadMoreButton from "./load-more-button";
-import { useSpaceXPaginated } from "../utils/use-space-x";
+import Error from './error';
+import Breadcrumbs from './breadcrumbs';
+import FavouritesDrawer from './favouritesDrawer';
+import LoadMoreButton from './load-more-button';
+import { useSpaceXPaginated } from '../utils/use-space-x';
 
 const PAGE_SIZE = 12;
 
-export default function LaunchPads() {
-  const { data, error, isValidating, size, setSize } = useSpaceXPaginated(
-    "/launchpads",
-    {
-      limit: PAGE_SIZE,
-    }
-  );
+export default function LaunchPads({ favouriteLaunchPads, markAsFavouriteLaunchPad }) {
+	const { data, error, isValidating, size, setSize } = useSpaceXPaginated('/launchpads', {
+		limit: PAGE_SIZE
+	});
 
-  return (
-    <div>
-      <Breadcrumbs
-        items={[{ label: "Home", to: "/" }, { label: "Launch Pads" }]}
-      />
-      <SimpleGrid m={[2, null, 6]} minChildWidth="350px" spacing="4">
-        {error && <Error />}
-        {data &&
-          data
-            .flat()
-            .map((launchPad) => (
-              <LaunchPadItem key={launchPad.site_id} launchPad={launchPad} />
-            ))}
-      </SimpleGrid>
-      <LoadMoreButton
-        loadMore={() => setSize(size + 1)}
-        data={data}
-        pageSize={PAGE_SIZE}
-        isLoadingMore={isValidating}
-      />
-    </div>
-  );
+	return (
+		<div>
+			<Box d="flex" alignItems="baseline">
+				<Box width="85%">
+					<Breadcrumbs items={[{ label: 'Home', to: '/' }, { label: 'Launch Pads' }]} />
+				</Box>
+				<FavouritesDrawer
+					favouriteItems={favouriteLaunchPads}
+					markAsFavourite={markAsFavouriteLaunchPad}
+				/>
+			</Box>
+			<SimpleGrid m={[2, null, 6]} minChildWidth="350px" spacing="4">
+				{error && <Error />}
+				{data &&
+					data
+						.flat()
+						.map(launchPad => (
+							<LaunchPadItem
+								key={launchPad.site_id}
+								launchPad={launchPad}
+								favouriteLaunchPads={favouriteLaunchPads}
+								markAsFavouriteLaunchPad={markAsFavouriteLaunchPad}
+							/>
+						))}
+			</SimpleGrid>
+			<LoadMoreButton
+				loadMore={() => setSize(size + 1)}
+				data={data}
+				pageSize={PAGE_SIZE}
+				isLoadingMore={isValidating}
+			/>
+		</div>
+	);
 }
 
-function LaunchPadItem({ launchPad }) {
-  return (
-    <Box
-      as={Link}
-      to={`/launch-pads/${launchPad.site_id}`}
-      boxShadow="md"
-      borderWidth="1px"
-      rounded="lg"
-      overflow="hidden"
-      position="relative"
-    >
-      <Box p="6">
-        <Box d="flex" alignItems="baseline">
-          {launchPad.status === "active" ? (
-            <Badge px="2" variant="solid" variantColor="green">
-              Active
-            </Badge>
-          ) : (
-            <Badge px="2" variant="solid" variantColor="red">
-              Retired
-            </Badge>
-          )}
-          <Box
-            color="gray.500"
-            fontWeight="semibold"
-            letterSpacing="wide"
-            fontSize="xs"
-            textTransform="uppercase"
-            ml="2"
-          >
-            {launchPad.attempted_launches} attempted &bull;{" "}
-            {launchPad.successful_launches} succeeded
-          </Box>
-        </Box>
+export function LaunchPadItem({ launchPad, favouriteLaunchPads, markAsFavouriteLaunchPad }) {
+	const isFavourite = (favouriteLaunchPads || []).findIndex(item => item.id === launchPad.id) > -1;
+	return (
+		<Box
+			as={Link}
+			to={`/launch-pads/${launchPad.site_id}`}
+			boxShadow="md"
+			borderWidth="1px"
+			rounded="lg"
+			overflow="hidden"
+			position="relative"
+		>
+			<Box p="6">
+				<Box d="flex" alignItems="baseline">
+					{launchPad.status === 'active' ? (
+						<Badge px="2" variant="solid" variantColor="green">
+							Active
+						</Badge>
+					) : (
+						<Badge px="2" variant="solid" variantColor="red">
+							Retired
+						</Badge>
+					)}
+					<Box
+						color="gray.500"
+						fontWeight="semibold"
+						letterSpacing="wide"
+						fontSize="xs"
+						textTransform="uppercase"
+						ml="2"
+					>
+						{launchPad.attempted_launches} attempted &bull; {launchPad.successful_launches}{' '}
+						succeeded
+					</Box>
+				</Box>
 
-        <Box
-          mt="1"
-          fontWeight="semibold"
-          as="h4"
-          lineHeight="tight"
-          isTruncated
-        >
-          {launchPad.name}
-        </Box>
-        <Text color="gray.500" fontSize="sm">
-          {launchPad.vehicles_launched.join(", ")}
-        </Text>
-      </Box>
-    </Box>
-  );
+				<Box d="flex" alignItems="baseline">
+					<Box width="90%" mt="1" fontWeight="semibold" as="h4" lineHeight="tight" isTruncated>
+						{launchPad.name}
+					</Box>
+					<Box width="10%">
+						<IconButton
+							aria-label="Mark as favourite"
+							icon="star"
+							size="lg"
+							variant="ghost"
+							variantColor={isFavourite ? 'yellow' : 'gray'}
+							onClick={e => markAsFavouriteLaunchPad(launchPad, e)}
+						/>
+					</Box>
+				</Box>
+				<Text color="gray.500" fontSize="sm">
+					{launchPad.vehicles_launched.join(', ')}
+				</Text>
+			</Box>
+		</Box>
+	);
 }

--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -19,7 +19,8 @@ import {
 	Stack,
 	AspectRatioBox,
 	StatGroup,
-	Tooltip
+	Tooltip,
+	IconButton
 } from '@chakra-ui/core';
 
 import { useSpaceX } from '../utils/use-space-x';
@@ -27,7 +28,7 @@ import { formatDateTime } from '../utils/format-date';
 import Error from './error';
 import Breadcrumbs from './breadcrumbs';
 
-export default function Launch() {
+export default function Launch({ favouriteLaunches, markAsFavouriteLaunch }) {
 	let { launchId } = useParams();
 	const { data: launch, error } = useSpaceX(`/launches/${launchId}`);
 
@@ -40,6 +41,9 @@ export default function Launch() {
 		);
 	}
 
+	const isFavourite =
+		(favouriteLaunches || []).findIndex(item => item.flight_number === launch.flight_number) > -1;
+
 	return (
 		<div>
 			<Breadcrumbs
@@ -49,7 +53,11 @@ export default function Launch() {
 					{ label: `#${launch.flight_number}` }
 				]}
 			/>
-			<Header launch={launch} />
+			<Header
+				launch={launch}
+				isFavourite={isFavourite}
+				markAsFavouriteLaunch={markAsFavouriteLaunch}
+			/>
 			<Box m={[3, 6]}>
 				<TimeAndLocation launch={launch} />
 				<RocketInfo launch={launch} />
@@ -63,7 +71,7 @@ export default function Launch() {
 	);
 }
 
-function Header({ launch }) {
+function Header({ launch, isFavourite, markAsFavouriteLaunch }) {
 	return (
 		<Flex
 			bgImage={`url(${launch.links.flickr_images[0]})`}
@@ -85,17 +93,30 @@ function Header({ launch }) {
 				objectFit="contain"
 				objectPosition="bottom"
 			/>
-			<Heading
-				color="white"
-				display="inline"
-				backgroundColor="#718096b8"
-				fontSize={['lg', '5xl']}
-				px="4"
-				py="2"
-				borderRadius="lg"
-			>
-				{launch.mission_name}
-			</Heading>
+			<Box>
+				<Heading
+					color="white"
+					display="inline"
+					backgroundColor="#718096b8"
+					fontSize={['lg', '5xl']}
+					px="4"
+					py="2"
+					borderRadius="lg"
+				>
+					{launch.mission_name}
+				</Heading>
+				<IconButton
+					aria-label="Mark as favourite"
+					icon="star"
+					size="lg"
+					variant="ghost"
+					fontSize={['lg', '4xl']}
+					mb="5"
+					ml="5"
+					variantColor={isFavourite ? 'yellow' : 'gray'}
+					onClick={e => markAsFavouriteLaunch(launch, e)}
+				/>
+			</Box>
 			<Stack isInline spacing="3">
 				<Badge variantColor="purple" fontSize={['xs', 'md']}>
 					#{launch.flight_number}

--- a/src/components/launches.js
+++ b/src/components/launches.js
@@ -1,122 +1,140 @@
-import React from "react";
-import { Badge, Box, Image, SimpleGrid, Text, Flex } from "@chakra-ui/core";
-import { format as timeAgo } from "timeago.js";
-import { Link } from "react-router-dom";
+import React from 'react';
+import { Badge, Box, Image, SimpleGrid, Text, Flex, IconButton } from '@chakra-ui/core';
+import { format as timeAgo } from 'timeago.js';
+import { Link } from 'react-router-dom';
 
-import { useSpaceXPaginated } from "../utils/use-space-x";
-import { formatDate } from "../utils/format-date";
-import Error from "./error";
-import Breadcrumbs from "./breadcrumbs";
-import LoadMoreButton from "./load-more-button";
+import { useSpaceXPaginated } from '../utils/use-space-x';
+import { formatDate } from '../utils/format-date';
+import Error from './error';
+import Breadcrumbs from './breadcrumbs';
+import FavouritesDrawer from './favouritesDrawer';
+import LoadMoreButton from './load-more-button';
 
 const PAGE_SIZE = 12;
 
-export default function Launches() {
-  const { data, error, isValidating, setSize, size } = useSpaceXPaginated(
-    "/launches/past",
-    {
-      limit: PAGE_SIZE,
-      order: "desc",
-      sort: "launch_date_utc",
-    }
-  );
-  console.log(data, error);
-  return (
-    <div>
-      <Breadcrumbs
-        items={[{ label: "Home", to: "/" }, { label: "Launches" }]}
-      />
-      <SimpleGrid m={[2, null, 6]} minChildWidth="350px" spacing="4">
-        {error && <Error />}
-        {data &&
-          data
-            .flat()
-            .map((launch) => (
-              <LaunchItem launch={launch} key={launch.flight_number} />
-            ))}
-      </SimpleGrid>
-      <LoadMoreButton
-        loadMore={() => setSize(size + 1)}
-        data={data}
-        pageSize={PAGE_SIZE}
-        isLoadingMore={isValidating}
-      />
-    </div>
-  );
+export default function Launches({ favouriteLaunches, markAsFavouriteLaunch }) {
+	const { data, error, isValidating, setSize, size } = useSpaceXPaginated('/launches/past', {
+		limit: PAGE_SIZE,
+		order: 'desc',
+		sort: 'launch_date_utc'
+	});
+	console.log(data, error);
+
+	return (
+		<div>
+			<Box d="flex" alignItems="baseline">
+				<Box width="85%">
+					<Breadcrumbs items={[{ label: 'Home', to: '/' }, { label: 'Launches' }]} />
+				</Box>
+				<FavouritesDrawer
+					favouriteItems={favouriteLaunches}
+					markAsFavourite={markAsFavouriteLaunch}
+				/>
+			</Box>
+			<SimpleGrid m={[2, null, 6]} minChildWidth="350px" spacing="4">
+				{error && <Error />}
+				{data &&
+					data
+						.flat()
+						.map(launch => (
+							<LaunchItem
+								launch={launch}
+								key={launch.flight_number}
+								favouriteLaunches={favouriteLaunches}
+								markAsFavouriteLaunch={markAsFavouriteLaunch}
+							/>
+						))}
+			</SimpleGrid>
+			<LoadMoreButton
+				loadMore={() => setSize(size + 1)}
+				data={data}
+				pageSize={PAGE_SIZE}
+				isLoadingMore={isValidating}
+			/>
+		</div>
+	);
 }
 
-export function LaunchItem({ launch }) {
-  return (
-    <Box
-      as={Link}
-      to={`/launches/${launch.flight_number.toString()}`}
-      boxShadow="md"
-      borderWidth="1px"
-      rounded="lg"
-      overflow="hidden"
-      position="relative"
-    >
-      <Image
-        src={
-          launch.links.flickr_images[0]?.replace("_o.jpg", "_z.jpg") ??
-          launch.links.mission_patch_small
-        }
-        alt={`${launch.mission_name} launch`}
-        height={["200px", null, "300px"]}
-        width="100%"
-        objectFit="cover"
-        objectPosition="bottom"
-      />
+export function LaunchItem({ launch, favouriteLaunches, markAsFavouriteLaunch }) {
+	const isFavourite =
+		(favouriteLaunches || []).findIndex(item => item.flight_number === launch.flight_number) > -1;
 
-      <Image
-        position="absolute"
-        top="5"
-        right="5"
-        src={launch.links.mission_patch_small}
-        height="75px"
-        objectFit="contain"
-        objectPosition="bottom"
-      />
+	return (
+		<Box
+			as={Link}
+			to={`/launches/${launch.flight_number.toString()}`}
+			boxShadow="md"
+			borderWidth="1px"
+			rounded="lg"
+			overflow="hidden"
+			position="relative"
+		>
+			<Image
+				src={
+					launch.links.flickr_images[0]?.replace('_o.jpg', '_z.jpg') ??
+					launch.links.mission_patch_small
+				}
+				alt={`${launch.mission_name} launch`}
+				height={['200px', null, '300px']}
+				width="100%"
+				objectFit="cover"
+				objectPosition="bottom"
+			/>
 
-      <Box p="6">
-        <Box d="flex" alignItems="baseline">
-          {launch.launch_success ? (
-            <Badge px="2" variant="solid" variantColor="green">
-              Successful
-            </Badge>
-          ) : (
-            <Badge px="2" variant="solid" variantColor="red">
-              Failed
-            </Badge>
-          )}
-          <Box
-            color="gray.500"
-            fontWeight="semibold"
-            letterSpacing="wide"
-            fontSize="xs"
-            textTransform="uppercase"
-            ml="2"
-          >
-            {launch.rocket.rocket_name} &bull; {launch.launch_site.site_name}
-          </Box>
-        </Box>
+			<Image
+				position="absolute"
+				top="5"
+				right="5"
+				src={launch.links.mission_patch_small}
+				height="75px"
+				objectFit="contain"
+				objectPosition="bottom"
+			/>
 
-        <Box
-          mt="1"
-          fontWeight="semibold"
-          as="h4"
-          lineHeight="tight"
-          isTruncated
-        >
-          {launch.mission_name}
-        </Box>
-        <Flex>
-          <Text fontSize="sm">{formatDate(launch.launch_date_utc)} </Text>
-          <Text color="gray.500" ml="2" fontSize="sm">
-            {timeAgo(launch.launch_date_utc)}
-          </Text>
-        </Flex>
-      </Box>
-    </Box>
-  );
+			<Box p="6">
+				<Box d="flex" alignItems="baseline">
+					{launch.launch_success ? (
+						<Badge px="2" variant="solid" variantColor="green">
+							Successful
+						</Badge>
+					) : (
+						<Badge px="2" variant="solid" variantColor="red">
+							Failed
+						</Badge>
+					)}
+					<Box
+						color="gray.500"
+						fontWeight="semibold"
+						letterSpacing="wide"
+						fontSize="xs"
+						textTransform="uppercase"
+						ml="2"
+					>
+						{launch.rocket.rocket_name} &bull; {launch.launch_site.site_name}
+					</Box>
+				</Box>
+				<Box d="flex" alignItems="baseline">
+					<Box width="90%" mt="1" fontWeight="semibold" as="h4" lineHeight="tight" isTruncated>
+						{launch.mission_name}
+					</Box>
+					<Box width="10%">
+						<IconButton
+							aria-label="Mark as favourite"
+							icon="star"
+							size="lg"
+							variant="ghost"
+							variantColor={isFavourite ? 'yellow' : 'gray'}
+							onClick={e => markAsFavouriteLaunch(launch, e)}
+						/>
+					</Box>
+				</Box>
+				<Flex>
+					<Text fontSize="sm">{formatDate(launch.launch_date_utc)} </Text>
+					<Text color="gray.500" ml="2" fontSize="sm">
+						{timeAgo(launch.launch_date_utc)}
+					</Text>
+				</Flex>
+			</Box>
+		</Box>
+	);
 }


### PR DESCRIPTION
Context: There needs to be added a "favorites" feature with the requirements described below.

Requirements:
- [x] a user can mark - "star" - launches or launch pads as favorites - both from the list and details page for all items
- [x] a list of favorites is available as a slide-in drawer (see the sketch below) from the list, the user can navigate to the favorite items
- [x] the user is able to remove items from the list (from within the list and on the details page of an item that is currently in the list)
- [x] the list is persisted after the app is closed (but everything is stored locally for now)


Sketch of the feature:
![image](https://user-images.githubusercontent.com/19324793/103483554-5e03f080-4de8-11eb-8014-dd4b2f126dbc.png)

This PR adds the functionality to add / remove a launch  or a launch pad as a favourite item and stores this data into _LocalStorage_. The list of favourite items is available from the slide-in drawer, which can be triggered from both overview pages of launches and launch pads. The drawer allows the option to remove a certain item as _favourite_ or navigate to the details page of a specific favourite item.

An item is marked as _favourite_ by a yellow star ⭐️  which can be observed on the overview page (next to each item), on the details page of a specific item (next to the item's name) and next to the name of the item in the list of favourite items presented in the slide-in drawer. The icon itself is different than the one presented in the design. This is due to the fact that the UI components used (UI Chakra https://v0.chakra-ui.com/icon) do not support an icon similar to the one used by design. For consistency reasons, there hasn't been used another icon from a different library. Moreover, the star icon is widely used across the web to indicate an item as _starred_ or _favourite_ and it would come as a natural action to the users.